### PR TITLE
Update Find command to search using Person's IC

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -5,24 +5,24 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.IdentityCardNumberMatchesPredicate;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Finds and lists all persons in address book whose IC matches the argument IC.
+ * Keyword matching is case-insensitive.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose profile matches "
+            + "the specified IC (case-insensitive) and displays them.\n"
+            + "Parameters: IC\n"
+            + "Example: " + COMMAND_WORD + " t1234567A";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final IdentityCardNumberMatchesPredicate predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(IdentityCardNumberMatchesPredicate predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -2,11 +2,10 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.Arrays;
-
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.IdentityCardNumber;
+import seedu.address.model.person.IdentityCardNumberMatchesPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -25,9 +24,12 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        try {
+            IdentityCardNumber IC = new IdentityCardNumber(trimmedArgs);
+            return new FindCommand(new IdentityCardNumberMatchesPredicate(IC));
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE), e);
+        }
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -25,8 +25,8 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         try {
-            IdentityCardNumber IC = new IdentityCardNumber(trimmedArgs);
-            return new FindCommand(new IdentityCardNumberMatchesPredicate(IC));
+            IdentityCardNumber ic = ParserUtil.parseIC(trimmedArgs);
+            return new FindCommand(new IdentityCardNumberMatchesPredicate(ic));
         } catch (IllegalArgumentException e) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE), e);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -11,6 +11,7 @@ import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.IdentityCardNumber;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -63,6 +64,21 @@ public class ParserUtil {
             throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
         }
         return new Phone(trimmedPhone);
+    }
+
+    /**
+     * Parses a {@code String identityCardNumber} into a {@code IdentityCardNumber}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code identityCardNumber} is invalid.
+     */
+    public static IdentityCardNumber parseIC(String identityCardNumber) throws ParseException {
+        requireNonNull(identityCardNumber);
+        String trimmedIdentityCardNumber = identityCardNumber.trim();
+        if (!IdentityCardNumber.isValidIdentityCardNumber(trimmedIdentityCardNumber)) {
+            throw new ParseException(IdentityCardNumber.MESSAGE_CONSTRAINTS);
+        }
+        return new IdentityCardNumber(trimmedIdentityCardNumber);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/IdentityCardNumber.java
+++ b/src/main/java/seedu/address/model/person/IdentityCardNumber.java
@@ -14,7 +14,7 @@ public class IdentityCardNumber {
         "IC number starts with one letter (S,T,F,G,M) followed by seven digits and one letter behind"
             + " It is case insensitive. An example is S1234567A.";
 
-    public static final String VALIDATION_REGEX = "[STFGM][0-9]{7}[A-Z]";
+    public static final String VALIDATION_REGEX = "[STFGMstfgm][0-9]{7}[A-Z,a-z]";
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/person/IdentityCardNumberMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/person/IdentityCardNumberMatchesPredicate.java
@@ -1,0 +1,42 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code IdentityCardNumber} matches the given IC number.
+ */
+public class IdentityCardNumberMatchesPredicate implements Predicate<Person> {
+    private final IdentityCardNumber targetIcNumber;
+
+    public IdentityCardNumberMatchesPredicate(IdentityCardNumber targetIcNumber) {
+        this.targetIcNumber = targetIcNumber;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getIdentityCardNumber().equals(targetIcNumber);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof IdentityCardNumberMatchesPredicate)) {
+            return false;
+        }
+
+        IdentityCardNumberMatchesPredicate predicate = (IdentityCardNumberMatchesPredicate) other;
+        return targetIcNumber.equals(predicate.targetIcNumber);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).toString();
+    }
+
+}
+

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -5,12 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalPersons.CARL;
-import static seedu.address.testutil.TypicalPersons.ELLE;
-import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
-import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
@@ -18,21 +15,23 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.IdentityCardNumber;
+import seedu.address.model.person.IdentityCardNumberMatchesPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
+
 public class FindCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        IdentityCardNumberMatchesPredicate firstPredicate =
+                new IdentityCardNumberMatchesPredicate(new IdentityCardNumber("S1234567A"));
+        IdentityCardNumberMatchesPredicate secondPredicate =
+                new IdentityCardNumberMatchesPredicate(new IdentityCardNumber("S9876543B"));
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
@@ -55,28 +54,19 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+    public void execute_validIC_singlePersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        IdentityCardNumberMatchesPredicate predicate = preparePredicate("S1234567A");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
-    }
-
-    @Test
-    public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
+        assertEquals(Collections.singletonList(ALICE), model.getFilteredPersonList());
     }
 
     @Test
     public void toStringMethod() {
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
+        IdentityCardNumberMatchesPredicate predicate = new IdentityCardNumberMatchesPredicate(
+                new IdentityCardNumber("S1234567A"));
         FindCommand findCommand = new FindCommand(predicate);
         String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
         assertEquals(expected, findCommand.toString());
@@ -85,7 +75,8 @@ public class FindCommandTest {
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private IdentityCardNumberMatchesPredicate preparePredicate(String userInput) {
+        return new IdentityCardNumberMatchesPredicate(new IdentityCardNumber(userInput));
     }
 }
+

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -7,10 +7,6 @@ import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +20,8 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.IdentityCardNumber;
+import seedu.address.model.person.IdentityCardNumberMatchesPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -72,10 +69,9 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_find() throws Exception {
-        List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        String args = "s1234567a";
+        FindCommand command = (FindCommand) parser.parseCommand(FindCommand.COMMAND_WORD + " " + args);
+        assertEquals(new FindCommand(new IdentityCardNumberMatchesPredicate(new IdentityCardNumber(args))), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -35,15 +35,13 @@ public class FindCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         // IC with incorrect format
-        assertParseFailure(parser, "S1234", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "S1234", IdentityCardNumber.MESSAGE_CONSTRAINTS);
 
         // IC with incorrect format and additional arguments
-        assertParseFailure(parser, "S1234 extra", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "S1234 extra", IdentityCardNumber.MESSAGE_CONSTRAINTS);
 
         // IC with correct format but contains non-alphanumeric characters
-        assertParseFailure(parser, "S1234$%^", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "S1234$%^", IdentityCardNumber.MESSAGE_CONSTRAINTS);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -3,13 +3,13 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-
-import java.util.Arrays;
+import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.IdentityCardNumber;
+import seedu.address.model.person.IdentityCardNumberMatchesPredicate;
 
 public class FindCommandParserTest {
 
@@ -22,13 +22,33 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsFindCommand() {
-        // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+                new FindCommand(new IdentityCardNumberMatchesPredicate(new IdentityCardNumber("S1234567A")));
+        assertParseSuccess(parser, "S1234567A", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, " \n"
+                + " S1234567A \n"
+                + " \t  \t", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // IC with incorrect format
+        assertParseFailure(parser, "S1234", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+        // IC with incorrect format and additional arguments
+        assertParseFailure(parser, "S1234 extra", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindCommand.MESSAGE_USAGE));
+
+        // IC with correct format but contains non-alphanumeric characters
+        assertParseFailure(parser, "S1234$%^", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_nullArgs_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> parser.parse(null));
     }
 
 }


### PR DESCRIPTION
Added support for usage of find command (Closes https://github.com/AY2324S2-CS2103T-F14-2/tp/issues/10). This PR covers:

- New Class (IdentityCardNumberMatchesPredicate) to support searching of IC in FindCommand Class.
- Ensuring that the parsing of arguments with the command word `find` is updated with the new class.
- Updating Unit tests to ensure that FindCommand runs and throws errors where necessary.
- The program can compile and run without a problem.

If one of these points above still has an issue please let me know. The FindCommand Class now looks like this:
![Screenshot 2024-03-16 at 2 43 48 PM](https://github.com/AY2324S2-CS2103T-F14-2/tp/assets/121473213/f0c63dfe-82e6-4b48-90e0-a23fc84aac16)

Note:
- The command has yet to be tried on the actual interface as the AddCommand has to be updated first.