### PR TITLE
Create UML diagram using PlantUML for addnotecommand function

### DIFF
--- a/docs/diagrams/AddNoteSequenceDiagram.puml
+++ b/docs/diagrams/AddNoteSequenceDiagram.puml
@@ -1,0 +1,70 @@
+@startuml
+!include style.puml
+skinparam ArrowFontStyle plain
+
+box Logic LOGIC_COLOR_T1
+participant ":LogicManager" as LogicManager LOGIC_COLOR
+participant ":AddressBookParser" as AddressBookParser LOGIC_COLOR
+participant ":AddNoteCommandParser" as AddNoteCommandParser LOGIC_COLOR
+participant "n:AddNoteCommand" as AddNoteCommand LOGIC_COLOR
+participant "r:CommandResult" as CommandResult LOGIC_COLOR
+end box
+
+box Model MODEL_COLOR_T1
+participant "m:Model" as Model MODEL_COLOR
+end box
+
+[-> LogicManager : execute("addnote \n i/T0123456A n/Covid")
+activate LogicManager
+
+LogicManager -> AddressBookParser : parseCommand("addnote \n i/T0123456A n/Covid")
+activate AddressBookParser
+
+create AddNoteCommandParser
+AddressBookParser -> AddNoteCommandParser
+activate AddNoteCommandParser
+
+AddNoteCommandParser --> AddressBookParser
+deactivate AddNoteCommandParser
+
+AddressBookParser -> AddNoteCommandParser : parse("i/T0123456A n/Covid")
+activate AddNoteCommandParser
+
+create AddNoteCommand
+AddNoteCommandParser -> AddNoteCommand
+activate AddNoteCommand
+
+AddNoteCommand --> AddNoteCommandParser :
+deactivate AddNoteCommand
+
+AddNoteCommandParser --> AddressBookParser : n
+deactivate AddNoteCommandParser
+'Hidden arrow to position the destroy marker below the end of the activation bar.
+AddNoteCommandParser -[hidden]-> AddressBookParser
+destroy AddNoteCommandParser
+
+AddressBookParser --> LogicManager : n
+deactivate AddressBookParser
+
+LogicManager -> AddNoteCommand : execute(m)
+activate AddNoteCommand
+
+AddNoteCommand -> Model : setPerson(T0123456A, \n new Person(..., Covid, ...))
+activate Model
+
+Model --> AddNoteCommand
+deactivate Model
+
+create CommandResult
+AddNoteCommand -> CommandResult
+activate CommandResult
+
+CommandResult --> AddNoteCommand
+deactivate CommandResult
+
+AddNoteCommand --> LogicManager : r
+deactivate AddNoteCommand
+
+[<--LogicManager
+deactivate LogicManager
+@enduml


### PR DESCRIPTION
Created UML diagram for AddNoteCommand using PlantUML. (Closes #69).

This PR covers:

* Created a new .puml file for the creation of addnotcommand uml diagram
* UML diagram itself

What the sequence diagram looks like:
<img width="930" alt="Screenshot 2024-03-20 at 9 49 43 PM" src="https://github.com/AY2324S2-CS2103T-F14-2/tp/assets/122196137/0ad171e2-8e2b-45e7-8a8b-efe495e3dd14">