### PR TITLE
Add UML diagram for add command and edit command

### DIFF
--- a/docs/diagrams/AddCommandDiagram.puml
+++ b/docs/diagrams/AddCommandDiagram.puml
@@ -1,0 +1,70 @@
+@startuml
+!include style.puml
+skinparam ArrowFontStyle plain
+
+box Logic LOGIC_COLOR_T1
+participant ":LogicManager" as LogicManager LOGIC_COLOR
+participant ":AddressBookParser" as AddressBookParser LOGIC_COLOR
+participant ":AddCommandParser" as AddCommandParser LOGIC_COLOR
+participant "d:AddCommand" as AddCommand LOGIC_COLOR
+participant "r:CommandResult" as CommandResult LOGIC_COLOR
+end box
+
+box Model MODEL_COLOR_T1
+participant "m:Model" as Model MODEL_COLOR
+end box
+
+[-> LogicManager : execute("add n/John Doe p/12345678 e/john@mail.com i/T0123456A ag/12 s/Male a/John street, block 123, #01-01")
+activate LogicManager
+
+LogicManager -> AddressBookParser : parseCommand("add n/John Doe p/12345678 e/john@mail.com i/T0123456A ag/12 s/Male a/John street, block 123, #01-01")
+activate AddressBookParser
+
+create AddCommandParser
+AddressBookParser -> AddCommandParser
+activate AddCommandParser
+
+AddCommandParser --> AddressBookParser
+deactivate AddCommandParser
+
+AddressBookParser -> AddCommandParser : parse("n/John Doe p/12345678 e/john@mail.com i/T0123456A ag/12 s/Male a/John street, block 123, #01-01")
+activate AddCommandParser
+
+create AddCommand
+AddCommandParser -> AddCommand
+activate AddCommand
+
+AddCommand --> AddCommandParser :
+deactivate AddCommand
+
+AddCommandParser --> AddressBookParser : a
+deactivate AddCommandParser
+'Hidden arrow to position the destroy marker below the end of the activation bar.
+AddCommandParser -[hidden]-> AddressBookParser
+destroy AddCommandParser
+
+AddressBookParser --> LogicManager : a
+deactivate AddressBookParser
+
+LogicManager -> AddCommand : execute(m)
+activate AddCommand
+
+AddCommand -> Model : setPerson(T0123456A, \n new Person(John Doe, 12345678, ...))
+activate Model
+
+Model --> AddCommand
+deactivate Model
+
+create CommandResult
+AddCommand -> CommandResult
+activate CommandResult
+
+CommandResult --> AddCommand
+deactivate CommandResult
+
+AddCommand --> LogicManager : r
+deactivate AddCommand
+
+[<--LogicManager
+deactivate LogicManager
+@enduml

--- a/docs/diagrams/EditCommandDiagram.puml
+++ b/docs/diagrams/EditCommandDiagram.puml
@@ -1,0 +1,70 @@
+@startuml
+!include style.puml
+skinparam ArrowFontStyle plain
+
+box Logic LOGIC_COLOR_T1
+participant ":LogicManager" as LogicManager LOGIC_COLOR
+participant ":AddressBookParser" as AddressBookParser LOGIC_COLOR
+participant ":EditCommandParser" as EditCommandParser LOGIC_COLOR
+participant "d:EditCommand" as EditCommand LOGIC_COLOR
+participant "r:CommandResult" as CommandResult LOGIC_COLOR
+end box
+
+box Model MODEL_COLOR_T1
+participant "m:Model" as Model MODEL_COLOR
+end box
+
+[-> LogicManager : execute("edit T0123456A p/23456789")
+activate LogicManager
+
+LogicManager -> AddressBookParser : parseCommand("edit T0123456A p/23456789")
+activate AddressBookParser
+
+create EditCommandParser
+AddressBookParser -> EditCommandParser
+activate EditCommandParser
+
+EditCommandParser --> AddressBookParser
+deactivate EditCommandParser
+
+AddressBookParser -> EditCommandParser : parse("p/23456789")
+activate EditCommandParser
+
+create EditCommand
+EditCommandParser -> EditCommand
+activate EditCommand
+
+EditCommand --> EditCommandParser :
+deactivate EditCommand
+
+EditCommandParser --> AddressBookParser : e
+deactivate EditCommandParser
+'Hidden arrow to position the destroy marker below the end of the activation bar.
+EditCommandParser -[hidden]-> AddressBookParser
+destroy EditCommandParser
+
+AddressBookParser --> LogicManager : e
+deactivate AddressBookParser
+
+LogicManager -> EditCommand : execute(m)
+activate EditCommand
+
+EditCommand -> Model : setPerson(T0123456A, \n new Person(John Doe, 23456789, ...))
+activate Model
+
+Model --> EditCommand
+deactivate Model
+
+create CommandResult
+EditCommand -> CommandResult
+activate CommandResult
+
+CommandResult --> EditCommand
+deactivate CommandResult
+
+EditCommand --> LogicManager : r
+deactivate EditCommand
+
+[<--LogicManager
+deactivate LogicManager
+@enduml


### PR DESCRIPTION
Created UML diagram for AddCommand and Editcommand using PlantUML. (Closes #72)

This PR covers:

Created a new .puml file for the creation of add command and edit command uml diagram
UML diagram itself

UML diagram for add command:
![AddCommandDiagram](https://github.com/AY2324S2-CS2103T-F14-2/tp/assets/122381620/00fc6032-0168-4ec4-9c9f-db520036d995)

UML diagram for edit command:
![EditCommandDiagram](https://github.com/AY2324S2-CS2103T-F14-2/tp/assets/122381620/05e21f4b-fc24-4f78-a4a8-8e18d0c97610)
