### PR TITLE
Update addnote to not include ic prefix

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_IC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
@@ -26,11 +25,10 @@ public class AddNoteCommand extends Command {
             + "Existing remark will be appended by default. "
             + "To replace the original note, add -replace at the end of your command. "
             + "E.g. addnote i/S0123456Q n/Diabetes -replace\n"
-            + "Parameters: "
-            + PREFIX_IC + "IC "
+            + "Parameters: IC (National Registration Identity Card) "
             + PREFIX_NOTE + "NOTE \n"
-            + "Example: " + COMMAND_WORD + " "
-            + PREFIX_IC + "S0123456Q "
+            + "Example: " + COMMAND_WORD
+            + " S0123456Q "
             + PREFIX_NOTE + "Diabetes";
 
 

--- a/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FLAG;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_IC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 
 import java.util.stream.Stream;
@@ -26,10 +25,11 @@ public class AddNoteCommandParser implements Parser<AddNoteCommand> {
      */
     public AddNoteCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_IC, PREFIX_NOTE, PREFIX_FLAG);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NOTE, PREFIX_FLAG);
+        String trimmedArgs = args.trim();
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_IC, PREFIX_NOTE)
-                || !argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_NOTE)
+                || trimmedArgs.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
         }
 
@@ -47,7 +47,7 @@ public class AddNoteCommandParser implements Parser<AddNoteCommand> {
                 note = argMultimap.getValue(PREFIX_NOTE).orElse("");
             }
 
-            ic = ParserUtil.parseIC(argMultimap.getValue(PREFIX_IC).get());
+            ic = ParserUtil.parseIC(argMultimap.getPreamble());
             return new AddNoteCommand(new IdentityCardNumberMatchesPredicate(ic), new Note(note), isReplace);
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE), ive);

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -19,7 +19,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SEX_AMY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FLAG;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_IC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -117,8 +116,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_addNote_withReplaceFlag() throws Exception {
         final Note note = new Note("Some note.");
-        AddNoteCommand command = (AddNoteCommand) parser.parseCommand(AddNoteCommand.COMMAND_WORD + " "
-                + PREFIX_IC + "S0123456Q " + PREFIX_NOTE + note.value + " " + PREFIX_FLAG);
+        AddNoteCommand command = (AddNoteCommand) parser.parseCommand(AddNoteCommand.COMMAND_WORD
+                + " S0123456Q " + PREFIX_NOTE + note.value + " " + PREFIX_FLAG);
         assertEquals(new AddNoteCommand(new IdentityCardNumberMatchesPredicate(new IdentityCardNumber("S0123456Q")),
                 note, true), command);
     }
@@ -126,8 +125,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_addNote_withoutReplaceFlag() throws Exception {
         final Note note = new Note("Some note.");
-        AddNoteCommand command = (AddNoteCommand) parser.parseCommand(AddNoteCommand.COMMAND_WORD + " "
-                + PREFIX_IC + "S0123456Q " + PREFIX_NOTE + note.value);
+        AddNoteCommand command = (AddNoteCommand) parser.parseCommand(AddNoteCommand.COMMAND_WORD
+                + " S0123456Q " + PREFIX_NOTE + note.value);
         assertEquals(new AddNoteCommand(new IdentityCardNumberMatchesPredicate(new IdentityCardNumber("S0123456Q")),
                 note, false), command);
     }


### PR DESCRIPTION
This PR contains:
* Updated addnote message to not contain the ic prefix
* Updated addnote parser to accept only commands without ic prefix
* Updated addressbookparsertest file's test cases to not contain ic prefix for addnote tests

Closes #96.