### PR TITLE
Update build-and-prerelease.yml

### DIFF
--- a/.github/workflows/build-and-prerelease.yml
+++ b/.github/workflows/build-and-prerelease.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
 
+permissions: write-all
+
 jobs:
   build:
     if: github.event.pull_request.merged == true
@@ -55,7 +57,7 @@ jobs:
 
       - name: Create Pre-Release
         id: create_pre_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           draft: false
           prerelease: true


### PR DESCRIPTION
Prevents development release failures due to lacking write permissions and node deprecated warning.