### PR TITLE
Update addnote to display full list when nonexistent ic is used

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
@@ -51,14 +52,14 @@ public class AddNoteCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        model.updateFilteredPersonList(icPredicate);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        requireNonNull(model);
+        List<Person> allPatients = model.getAddressBook().getPersonList();
 
-        if (lastShownList.isEmpty()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON);
-        }
+        Person personToEdit = allPatients.stream()
+                .filter(icPredicate::test)
+                .findFirst()
+                .orElseThrow(() -> new CommandException(Messages.MESSAGE_NO_MATCHING_IC));
 
-        Person personToEdit = lastShownList.get(0);
         Person editedPerson;
 
         if (isReplace || personToEdit.getNote().equals(Note.DEFAULT)) {


### PR DESCRIPTION
Change execute method of addnote command class such that the full list is still displayed when a non-existent ic is keyed in (to match the edit command).

What the addnote command outputs with invalid ic is keyed in:
<img width="922" alt="Screenshot 2024-03-24 at 4 04 04 PM" src="https://github.com/AY2324S2-CS2103T-F14-2/tp/assets/122196137/c59e58c5-d8e4-4d7a-92df-c802f5596d0a">

Closes #112.