### PR TITLE
QOL bug updates

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -14,7 +14,6 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON = "The ic number provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_IC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
@@ -26,14 +25,14 @@ public class AddNoteCommand extends Command {
             + "the specified IC (must be a valid identity card number). \n"
             + "Existing remark will be appended by default. \n"
             + "Parameters: "
-            + PREFIX_IC + "IC "
+            + "IC "
             + PREFIX_NOTE + "NOTE \n"
-            + "Example: " + COMMAND_WORD + " "
-            + PREFIX_IC + "S0123456Q "
+            + "Example: " + COMMAND_WORD
+            + " S0123456Q "
             + PREFIX_NOTE + "Diabetes \n"
             + "To replace the original note, add -replace at the end of your command. \n"
-            + "Example: " + COMMAND_WORD + " "
-            + PREFIX_IC + "S0123456Q "
+            + "Example: " + COMMAND_WORD
+            + " S0123456Q "
             + PREFIX_NOTE + "Diabetes -replace";
 
     public static final String MESSAGE_MODIFY_NOTE_SUCCESS = "Note for %1$s (ic: %2$s) modified successfully!";

--- a/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
@@ -26,10 +26,8 @@ public class AddNoteCommandParser implements Parser<AddNoteCommand> {
     public AddNoteCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NOTE, PREFIX_FLAG);
-        String trimmedArgs = args.trim();
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NOTE)
-                || trimmedArgs.isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_NOTE)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
@@ -33,8 +33,8 @@ public class AddNoteCommandParser implements Parser<AddNoteCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
         }
 
-        IdentityCardNumber ic;
         try {
+            IdentityCardNumber ic = ParserUtil.parseIC(argMultimap.getPreamble());
             String note = "";
             boolean isReplace = false;
 
@@ -47,10 +47,9 @@ public class AddNoteCommandParser implements Parser<AddNoteCommand> {
                 note = argMultimap.getValue(PREFIX_NOTE).orElse("");
             }
 
-            ic = ParserUtil.parseIC(argMultimap.getPreamble());
             return new AddNoteCommand(new IdentityCardNumberMatchesPredicate(ic), new Note(note), isReplace);
         } catch (IllegalValueException ive) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE), ive);
+            throw new ParseException(String.format(IdentityCardNumber.MESSAGE_CONSTRAINTS), ive);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,6 +15,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_NOTE = new Prefix("n/");
-    public static final Prefix PREFIX_IC = new Prefix("i/");
     public static final Prefix PREFIX_FLAG = new Prefix("-replace");
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -23,7 +23,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             return new DeleteCommand(new IdentityCardNumberMatchesPredicate(ic));
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(IdentityCardNumber.MESSAGE_CONSTRAINTS), pe);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import seedu.address.logic.commands.AddNoteCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.IdentityCardNumber;
@@ -18,6 +20,13 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        String trimmedArgs = args.trim();
+
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
+        }
+
         try {
             IdentityCardNumber ic = ParserUtil.parseIC(args);
             return new DeleteCommand(new IdentityCardNumberMatchesPredicate(ic));

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import seedu.address.logic.commands.AddNoteCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.IdentityCardNumber;
@@ -23,8 +22,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         requireNonNull(args);
         String trimmedArgs = args.trim();
 
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
+        if (trimmedArgs.isEmpty() || trimmedArgs.contains(" ")) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
 
         try {

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -35,7 +35,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_IC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_IC_NUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SEX;
@@ -98,7 +98,7 @@ public class AddCommandParserTest {
 
         // multiple ic
         assertParseFailure(parser, IC_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_IC));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_IC_NUMBER));
 
         // multiple age
         assertParseFailure(parser, AGE_DESC_AMY + validExpectedPersonString,
@@ -146,7 +146,7 @@ public class AddCommandParserTest {
 
         // invalid ic
         assertParseFailure(parser, INVALID_IC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_IC));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_IC_NUMBER));
 
         // valid value followed by invalid value
 
@@ -176,7 +176,7 @@ public class AddCommandParserTest {
 
         // invalid ic
         assertParseFailure(parser, validExpectedPersonString + INVALID_IC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_IC));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_IC_NUMBER));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddNoteCommand;
-import seedu.address.model.person.IdentityCardNumber;
 
 public class AddNoteCommandParserTest {
     private AddNoteCommandParser parser = new AddNoteCommandParser();

--- a/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
@@ -1,11 +1,13 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddNoteCommand;
+import seedu.address.model.person.IdentityCardNumber;
 
 public class AddNoteCommandParserTest {
     private AddNoteCommandParser parser = new AddNoteCommandParser();
@@ -18,7 +20,16 @@ public class AddNoteCommandParserTest {
         // no parameters
         assertParseFailure(parser, AddNoteCommand.COMMAND_WORD, expectedMessage);
 
-        // no index
-        assertParseFailure(parser, AddNoteCommand.COMMAND_WORD + " " + nonEmptyNote, expectedMessage);
+        // no ic and note
+        assertParseFailure(parser, AddNoteCommand.COMMAND_WORD + " " + nonEmptyNote,
+                expectedMessage);
+
+        // no ic
+        assertParseFailure(parser, AddNoteCommand.COMMAND_WORD + PREFIX_NOTE + nonEmptyNote,
+                expectedMessage);
+
+        // no note
+        assertParseFailure(parser, AddNoteCommand.COMMAND_WORD + "s0123456a",
+                expectedMessage);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -31,14 +31,17 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         // IC with incorrect format
-        assertParseFailure(parser, "S1234", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "S1234", String.format(IdentityCardNumber.MESSAGE_CONSTRAINTS));
 
         // IC with incorrect format and additional arguments
-        assertParseFailure(parser, "S1234 extra", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "S1234 extra",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
 
-        // IC with correct format but contains non-alphanumeric characters
-        assertParseFailure(parser, "S1234$%^", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DeleteCommand.MESSAGE_USAGE));
+        // IC with incorrect format containing non-alphanumeric characters
+        assertParseFailure(parser, "S1234$%^", String.format(IdentityCardNumber.MESSAGE_CONSTRAINTS));
+
+        // IC with correct format but with additional arguments
+        assertParseFailure(parser, "S1234567A extra",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
This PR includes: 
* addnote uses i/IC n/NOTE while edit doesn't use 'i/' prefix --> removed the prefix for addnote
* addnote and delete t0123 will print the default invalid command message -> should print INVALID_IC_ERROR message instead --> editted logic to print correctly
* removed unused imports and variables

The error messages look like this now:
For delete --
<img width="919" alt="Screenshot 2024-03-25 at 12 12 07 AM" src="https://github.com/AY2324S2-CS2103T-F14-2/tp/assets/122196137/f27065b3-5fa0-449b-b491-013179fd0be3">

For addnote --
<img width="917" alt="Screenshot 2024-03-25 at 12 12 24 AM" src="https://github.com/AY2324S2-CS2103T-F14-2/tp/assets/122196137/cd2fb123-e4ff-4095-acd1-2d65901bd037">

Closes #105.
