### PR TITLE
Personcard UI

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -79,7 +79,8 @@ public class PersonCard extends UiPart<Region> {
                 String line = lines[i];
                 if (line.length() > maxLineLength) {
                     // Truncate the line and add an ellipsis
-                    truncatedNoteBuilder.append("            ").append(line.substring(0, maxLineLength)).append("...\n");
+                    truncatedNoteBuilder.append("            ")
+                            .append(line.substring(0, maxLineLength)).append("...\n");
                 } else {
                     truncatedNoteBuilder.append("            ").append(line).append("\n");
                 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -59,7 +59,36 @@ public class PersonCard extends UiPart<Region> {
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
         email.setText(person.getEmail().value);
-        note.setText(person.getNote().value);
+
+        String fullNote = person.getNote().value;
+        int maxLineLength = 30; // Maximum length of each line before truncation
+        String[] lines = fullNote.split("\\r?\\n"); // Split the note into lines
+
+        StringBuilder truncatedNoteBuilder = new StringBuilder();
+        if (lines.length > 0) {
+            String firstLine = lines[0];
+            if (firstLine.length() > maxLineLength) {
+                // Truncate the first line and add an ellipsis
+                truncatedNoteBuilder.append("Note: ").append(firstLine.substring(0, maxLineLength)).append("...\n");
+            } else {
+                truncatedNoteBuilder.append("Note: ").append(firstLine).append("\n");
+            }
+
+            // Append the rest of the lines with the same indentation
+            for (int i = 1; i < lines.length; i++) {
+                String line = lines[i];
+                if (line.length() > maxLineLength) {
+                    // Truncate the line and add an ellipsis
+                    truncatedNoteBuilder.append("            ").append(line.substring(0, maxLineLength)).append("...\n");
+                } else {
+                    truncatedNoteBuilder.append("            ").append(line).append("\n");
+                }
+            }
+        }
+
+        String truncatedNote = truncatedNoteBuilder.toString().trim(); // Remove trailing newline
+        note.setText(truncatedNote);
+
         ic.setText(person.getIdentityCardNumber().value);
         age.setText(String.valueOf(person.getAge().value));
         sex.setText(person.getSex().value);

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -52,8 +52,7 @@
         <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       </HBox>
       <HBox spacing="5" alignment="TOP_LEFT">
-        <Label text="Note:" styleClass="cell_small_label" />
-        <Label fx:id="note" styleClass="cell_small_label" text="\$note" />
+        <Label fx:id="note" styleClass="cell_small_label" text="\$note"/>
       </HBox>
     </VBox>
   </GridPane>


### PR DESCRIPTION
Editted the UI of the person card note display to truncate at the end of the note if its too long. I was thinking instead of displaying the full string regardless of the length will make each person card very long if they have many notes. Therefore, I decided to truncate the note if they get too long and users can just use the find command to show the entire note.

If yall have any other suggestions can let me know!

This is what it looks like:
<img width="1045" alt="Screenshot 2024-03-28 at 11 16 42 AM" src="https://github.com/AY2324S2-CS2103T-F14-2/tp/assets/122196137/25fb5e94-a10f-4bb6-987f-7aeea25796d5">

Closes #131.
