### PR TITLE
Update build.gradle file to enable assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,10 @@ test {
     finalizedBy jacocoTestReport
 }
 
+run {
+    enableAssertions = true
+}
+
 task coverage(type: JacocoReport) {
     sourceDirectories.from files(sourceSets.main.allSource.srcDirs)
     classDirectories.from files(sourceSets.main.output)


### PR DESCRIPTION
Enable assertions in team repo as required by one of the team tasks for 2103.

Closes #134.