### PR TITLE
Fix UI bugs for FindCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
@@ -87,7 +87,13 @@ public class AddNoteCommand extends Command {
         return new CommandResult(generateSuccessMessage(editedPerson));
     }
 
-    private boolean isNoteChanged(Person person, Note newNote) {
+    /**
+     * Checks if the note of the person is changed.
+     * @param person the person to be compared with
+     * @param newNote the new note to be compared with
+     * @return true if the note is changed, false otherwise
+     */
+    public boolean isNoteChanged(Person person, Note newNote) {
         if (person != null) {
             return !person.getNote().equals(newNote);
         }

--- a/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
@@ -77,7 +77,21 @@ public class AddNoteCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
+        Person person = FindCommand.getFoundPerson();
+        if (person != null && isNoteChanged(person, note)) {
+            model.updateFilteredPersonList(new IdentityCardNumberMatchesPredicate(person.getIdentityCardNumber()));
+            model.setDisplayNoteAsFirstFilteredPerson();
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        }
+
         return new CommandResult(generateSuccessMessage(editedPerson));
+    }
+
+    private boolean isNoteChanged(Person person, Note newNote) {
+        if (person != null) {
+            return !person.getNote().equals(newNote);
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 
@@ -74,14 +73,11 @@ public class AddNoteCommand extends Command {
                     personToEdit.getIdentityCardNumber(), personToEdit.getAge(), personToEdit.getSex(),
                     personToEdit.getAddress(), updatedNote, personToEdit.getTags());
         }
-        model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        Person person = FindCommand.getFoundPerson();
-        if (person != null && isNoteChanged(person, note)) {
-            model.updateFilteredPersonList(new IdentityCardNumberMatchesPredicate(person.getIdentityCardNumber()));
-            model.setDisplayNoteAsFirstFilteredPerson();
-            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.setPerson(personToEdit, editedPerson);
+
+        if (model.isPersonDisplayed(personToEdit)) {
+            model.setDisplayNote(editedPerson);
         }
 
         return new CommandResult(generateSuccessMessage(editedPerson));

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -6,6 +6,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.IdentityCardNumberMatchesPredicate;
+import seedu.address.model.person.Person;
 
 /**
  * Finds and lists all persons in address book whose IC matches the argument IC.
@@ -20,6 +21,8 @@ public class FindCommand extends Command {
             + "Parameters: IC (must be a valid identity card number) \n"
             + "Example: " + COMMAND_WORD + " t1234567A";
 
+    private static Person foundPerson = null;
+
     private final IdentityCardNumberMatchesPredicate predicate;
 
     public FindCommand(IdentityCardNumberMatchesPredicate predicate) {
@@ -31,8 +34,17 @@ public class FindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         model.setDisplayNoteAsFirstFilteredPerson();
+
+        if (model.getFilteredPersonList().size() == 1) {
+            foundPerson = model.getFilteredPersonList().get(0);
+        }
+
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    public static Person getFoundPerson() {
+        return foundPerson;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -18,7 +18,7 @@ public class FindCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose profile matches "
             + "the specified IC (case-insensitive) and displays them.\n"
-            + "Parameters: IC (must be a valid identity card number) \n"
+            + "Parameters: IC\n"
             + "Example: " + COMMAND_WORD + " t1234567A";
 
     private final IdentityCardNumberMatchesPredicate predicate;

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -21,8 +21,6 @@ public class FindCommand extends Command {
             + "Parameters: IC (must be a valid identity card number) \n"
             + "Example: " + COMMAND_WORD + " t1234567A";
 
-    private static Person foundPerson = null;
-
     private final IdentityCardNumberMatchesPredicate predicate;
 
     public FindCommand(IdentityCardNumberMatchesPredicate predicate) {
@@ -33,18 +31,16 @@ public class FindCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
-        model.setDisplayNoteAsFirstFilteredPerson();
+
+        assert model.getFilteredPersonList().size() <= 1 : "There should be at most one person in the filtered list";
 
         if (model.getFilteredPersonList().size() == 1) {
-            foundPerson = model.getFilteredPersonList().get(0);
+            Person person = model.getFilteredPersonList().get(0);
+            model.setDisplayNote(person);
         }
 
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
-    }
-
-    public static Person getFoundPerson() {
-        return foundPerson;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ShowCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowCommand.java
@@ -25,10 +25,10 @@ public class ShowCommand extends Command {
     public static final String MESSAGE_CLEAR_NOTE_SUCCESS = "Note cleared.";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows the note of the person whose IC matches the "
-            + "specified IC (case-insensitive) and displays it.\n"
-            + "If no IC is given, the displayed note panel will be cleared. \n"
+            + "specified valid IC (case-insensitive) and displays it.\n"
+            + "If no IC is given, the displayed note panel will be cleared.\n"
             + "Parameters: IC (optional)\n"
-            + "Example (to display note): " + COMMAND_WORD + " t1234567A"
+            + "Example (to display note): " + COMMAND_WORD + " t1234567A\n"
             + "Example (to clear display): " + COMMAND_WORD;
     private final IdentityCardNumberMatchesPredicate icPredicate;
 

--- a/src/main/java/seedu/address/logic/commands/ShowCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -93,6 +94,24 @@ public class ShowCommand extends Command {
         }
 
         ShowCommand e = (ShowCommand) other;
+        // icPredicate is not important if isClear is true
+        if (isClear && e.isClear) {
+            return true;
+        }
+        if (isClear != e.isClear) {
+            return false;
+        }
+        if (icPredicate == null || e.icPredicate == null) {
+            return icPredicate == e.icPredicate;
+        }
         return icPredicate.equals(e.icPredicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", icPredicate)
+                .add("isClear", isClear)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ShowCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -68,6 +69,9 @@ public class AddressBookParser {
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
+
+        case ShowCommand.COMMAND_WORD:
+            return new ShowCommandParser().parse(arguments);
 
         case AddNoteCommand.COMMAND_WORD:
             return new AddNoteCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/ShowCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ShowCommandParser.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.ShowCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.IdentityCardNumber;
+import seedu.address.model.person.IdentityCardNumberMatchesPredicate;
+
+/**
+ * Parses input arguments and creates a new ShowCommand object
+ */
+public class ShowCommandParser implements Parser<ShowCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ShowCommand
+     * and returns a ShowCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ShowCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            return ShowCommand.createClearCommand();
+        }
+
+        try {
+            IdentityCardNumber ic = ParserUtil.parseIC(trimmedArgs);
+            return ShowCommand.createShowCommand(new IdentityCardNumberMatchesPredicate(ic));
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowCommand.MESSAGE_USAGE), e);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -30,7 +30,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons = new UniquePersonList();
     }
 
-    private Optional<Note> displayNote = Optional.empty();
+    private Optional<Person> displayPerson = Optional.empty();
 
     public AddressBook() {}
 
@@ -102,22 +102,28 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Get the display note.
      */
     public Note getDisplayNote() {
-        return displayNote.orElse(Note.DEFAULT);
+        return displayPerson.map(Person::getNote).orElse(Note.EMPTY);
     }
 
     /**
-     * Sets the display note to the given note.
-     * @param note The note to be displayed.
+     * Set the display person.
      */
-    public void setDisplayNote(Note note) {
-        this.displayNote = Optional.of(note);
+    public void setDisplayPerson(Person person) {
+        this.displayPerson = Optional.of(person);
+    }
+
+    /**
+     * Check if person is displayed.
+     */
+    public boolean isPersonDisplayed(Person person) {
+        return displayPerson.isPresent() && displayPerson.get().isSamePerson(person);
     }
 
     /**
      * Clears the display note.
      */
-    public void clearDisplayNote() {
-        this.displayNote = Optional.empty();
+    public void clearDisplayPerson() {
+        this.displayPerson = Optional.empty();
     }
 
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -86,14 +86,21 @@ public interface Model {
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
 
+    /**
+     * Returns the display note.
+     */
     Note getDisplayNote();
 
+    /**
+     * Sets the displayed note to the note of the given person.
+     */
     void setDisplayNote(Person person);
 
     /**
-     * Replaces the note that is displayed in the note panel.
+     * Returns true if the person is displayed in the note panel.
      */
-    void setDisplayNote(Note note);
+    boolean isPersonDisplayed(Person person);
+
 
     /**
      * Sets the display note to the first filtered person.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -137,16 +137,15 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void setDisplayNote(Note note) {
-        requireNonNull(note);
-        addressBook.setDisplayNote(note);
+    public void setDisplayNote(Person person) {
+        requireNonNull(person);
+        addressBook.setDisplayPerson(person);
     }
 
     @Override
-    public void setDisplayNote(Person person) {
+    public boolean isPersonDisplayed(Person person) {
         requireNonNull(person);
-        Note displayNote = person.getNote();
-        setDisplayNote(displayNote);
+        return addressBook.isPersonDisplayed(person);
     }
 
     /**
@@ -168,7 +167,7 @@ public class ModelManager implements Model {
      */
     @Override
     public void clearDisplayNote() {
-        addressBook.clearDisplayNote();
+        addressBook.clearDisplayPerson();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Note.java
+++ b/src/main/java/seedu/address/model/person/Note.java
@@ -10,6 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Note {
 
     public static final Note DEFAULT = new Note("");
+    public static final Note EMPTY = new Note("");
     public static final String MESSAGE_CONSTRAINTS = "Notes can take any values, and it should not be blank";
 
     public final String value;

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -178,7 +178,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void setDisplayNote(Note note) {
+        public boolean isPersonDisplayed(Person person) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddNoteCommandTest.java
@@ -50,6 +50,70 @@ public class AddNoteCommandTest {
                 new IdentityCardNumberMatchesPredicate(personToEdit.getIdentityCardNumber()),
                 new Note("new note"), false).generateSuccessMessage(personToEdit));
     }
+    @Test
+    public void isNoteChanged_noteChanged_returnsTrue() {
+        // Setup
+        Person person = new PersonBuilder().withNote("old note").build();
+        Note newNote = new Note("new note");
+
+        // Action
+        boolean isChanged = new AddNoteCommand(
+                new IdentityCardNumberMatchesPredicate(person.getIdentityCardNumber()),
+                newNote, false).isNoteChanged(person, newNote);
+
+        // Verify
+        assertTrue(isChanged);
+    }
+
+    @Test
+    public void isNoteChanged_noteNotChanged_returnsFalse() {
+        // Setup
+        Person person = new PersonBuilder().withNote("same note").build();
+        Note sameNote = new Note("same note");
+
+        // Action
+        boolean isChanged = new AddNoteCommand(
+                new IdentityCardNumberMatchesPredicate(person.getIdentityCardNumber()),
+                sameNote, false).isNoteChanged(person, sameNote);
+
+        // Verify
+        assertFalse(isChanged);
+    }
+
+    @Test
+    public void execute_noteAdded_success() throws CommandException {
+        // Setup
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Person person = model.getFilteredPersonList().get(0);
+        AddNoteCommand command = new AddNoteCommand(
+                new IdentityCardNumberMatchesPredicate(person.getIdentityCardNumber()),
+                new Note("new note"), false);
+
+        // Action
+        CommandResult result = command.execute(model);
+
+        // Verify
+        assertEquals(String.format(AddNoteCommand.MESSAGE_MODIFY_NOTE_SUCCESS,
+                person.getName(), person.getIdentityCardNumber()), result.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_noteAppended_success() throws CommandException {
+        // Setup
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Person person = model.getFilteredPersonList().get(0);
+        Note originalNote = person.getNote();
+        AddNoteCommand command = new AddNoteCommand(
+                new IdentityCardNumberMatchesPredicate(person.getIdentityCardNumber()),
+                new Note("new note"), false);
+
+        // Action
+        command.execute(model);
+
+        // Verify
+        Person updatedPerson = model.getFilteredPersonList().get(0);
+        assertEquals(originalNote.append("\nnew note").toString(), updatedPerson.getNote().toString());
+    }
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/commands/ShowCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ShowCommandTest.java
@@ -1,0 +1,93 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.IdentityCardNumber;
+import seedu.address.model.person.IdentityCardNumberMatchesPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code ShowCommand}.
+ */
+public class ShowCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        IdentityCardNumberMatchesPredicate firstPredicate =
+                new IdentityCardNumberMatchesPredicate(new IdentityCardNumber("S1234567A"));
+        IdentityCardNumberMatchesPredicate secondPredicate =
+                new IdentityCardNumberMatchesPredicate(new IdentityCardNumber("S9876543B"));
+
+        ShowCommand showFirstCommand = ShowCommand.createShowCommand(firstPredicate);
+        ShowCommand showSecondCommand = ShowCommand.createShowCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(showFirstCommand.equals(showFirstCommand));
+
+        // same values -> returns true
+        ShowCommand showFirstCommandCopy = ShowCommand.createShowCommand(firstPredicate);
+        assertTrue(showFirstCommand.equals(showFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(showFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(showFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(showFirstCommand.equals(showSecondCommand));
+
+        // different isClear -> returns false
+        ShowCommand showFirstCommandClear = ShowCommand.createClearCommand();
+        assertFalse(showFirstCommand.equals(showFirstCommandClear));
+
+        // same isClear -> returns true
+        ShowCommand showSecondCommandClear = ShowCommand.createClearCommand();
+        assertTrue(showFirstCommandClear.equals(showSecondCommandClear));
+    }
+
+    @Test
+    public void execute_validIC_singlePersonFound() {
+        String testNumber = ALICE.getIdentityCardNumber().value;
+        String expectedMessage = String.format(ShowCommand.MESSAGE_SHOW_NOTE_SUCCESS, testNumber);
+        IdentityCardNumberMatchesPredicate predicate = preparePredicate(testNumber);
+        ShowCommand command = ShowCommand.createShowCommand(predicate);
+        expectedModel.setDisplayNote(ALICE);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noIC_clearNote() {
+        String expectedMessage = ShowCommand.MESSAGE_CLEAR_NOTE_SUCCESS;
+        ShowCommand command = ShowCommand.createClearCommand();
+        expectedModel.clearDisplayNote();
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void toStringMethod() {
+        IdentityCardNumberMatchesPredicate predicate = new IdentityCardNumberMatchesPredicate(
+                new IdentityCardNumber("S1234567A"));
+        ShowCommand showCommand = ShowCommand.createShowCommand(predicate);
+        String expected = ShowCommand.class.getCanonicalName() + "{predicate=" + predicate + ", isClear=" + "false}";
+        assertEquals(expected, showCommand.toString());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code IdentityCardNumberMatchesPredicate}.
+     */
+    private IdentityCardNumberMatchesPredicate preparePredicate(String userInput) {
+        return new IdentityCardNumberMatchesPredicate(new IdentityCardNumber(userInput));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ShowCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ShowCommandParserTest.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ShowCommand;
+import seedu.address.model.person.IdentityCardNumber;
+import seedu.address.model.person.IdentityCardNumberMatchesPredicate;
+
+public class ShowCommandParserTest {
+
+    private ShowCommandParser parser = new ShowCommandParser();
+
+    @Test
+    public void parse_emptyArg_returnsShowCommand() {
+        ShowCommand expectedShowCommand = ShowCommand.createClearCommand();
+        assertParseSuccess(parser, "", expectedShowCommand);
+        assertParseSuccess(parser, "       ", expectedShowCommand);
+        assertParseSuccess(parser, " \n \t \t", expectedShowCommand);
+    }
+
+    @Test
+    public void parse_validArgs_returnsShowCommand() {
+        ShowCommand expectedShowCommand = ShowCommand.createShowCommand(new IdentityCardNumberMatchesPredicate(
+                new IdentityCardNumber("S1234567A")));
+        assertParseSuccess(parser, "S1234567A", expectedShowCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n"
+                + " S1234567A \n"
+                + " \t  \t", expectedShowCommand);
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // IC with incorrect format
+        assertParseFailure(parser, "S1234", IdentityCardNumber.MESSAGE_CONSTRAINTS);
+
+        // IC with incorrect format and additional arguments
+        assertParseFailure(parser, "S1234 extra", IdentityCardNumber.MESSAGE_CONSTRAINTS);
+
+        // IC with correct format but contains non-alphanumeric characters
+        assertParseFailure(parser, "S1234$%^", IdentityCardNumber.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_nullArgs_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> parser.parse(null));
+    }
+
+}

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -104,19 +104,6 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void setDisplayedNote_validNote_setsDisplayedNote() {
-        Note note = Note.DEFAULT;
-        modelManager.setDisplayNote(note);
-        assertEquals(note, modelManager.getDisplayNote());
-    }
-
-    @Test
-    public void setDisplayedNote_nullNote_throwsNullPointerException() {
-        Note note = null;
-        assertThrows(NullPointerException.class, () -> modelManager.setDisplayNote(note));
-    }
-
-    @Test
     public void clearDisplayedNote_validNote_clearsDisplayedNote() {
         modelManager.setDisplayNote(ALICE);
         modelManager.clearDisplayNote();


### PR DESCRIPTION
Closes #133.

This PR covers:
- Implemented tracking of the `Person` whose note is displayed on the panel.
- Modified the `addnote` command to check if the note being added belongs to the tracked `Person`.

Concerns:
- Used a variable to track the `Person` in `find` command, and used `get` to retrieve the `Person` in `addnote` command
  - Not sure if this violates any rule (Single Responsibility Principle?)
 
Result after running `find s1234567b`:
 ![Screenshot 2024-03-29 at 3 22 23 PM](https://github.com/AY2324S2-CS2103T-F14-2/tp/assets/121473213/a82c459a-b518-4db6-a1f1-e4d15b095d38)
From the previous screen, running `addnote s1234567b n/Covid` will show the screen below:
![Screenshot 2024-03-29 at 3 23 28 PM](https://github.com/AY2324S2-CS2103T-F14-2/tp/assets/121473213/439d1d99-7c4a-467f-bed4-8a819f3991f9)