### PR TITLE
Fix ui display of personcard contents

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -57,8 +57,12 @@ public class PersonCard extends UiPart<Region> {
         this.person = person;
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
-        phone.setText(person.getPhone().value);
-        email.setText(person.getEmail().value);
+
+        StringBuilder truncatedPhone = new StringBuilder();
+        phone.setText(truncatedPhone.append("Phone: ").append(person.getPhone().value).toString());
+
+        StringBuilder truncatedEmail = new StringBuilder();
+        email.setText(truncatedEmail.append("Email: ").append(person.getEmail().value).toString());
 
         String fullNote = person.getNote().value;
         int maxLineLength = 30; // Maximum length of each line before truncation
@@ -93,7 +97,9 @@ public class PersonCard extends UiPart<Region> {
         ic.setText(person.getIdentityCardNumber().value);
         age.setText(String.valueOf(person.getAge().value));
         sex.setText(person.getSex().value);
-        address.setText(person.getAddress().value);
+
+        StringBuilder truncatedAddress = new StringBuilder();
+        address.setText(truncatedAddress.append("Address: ").append(person.getAddress().value).toString());
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -40,15 +40,12 @@
         <Label fx:id="ic" styleClass="cell_small_label" text="\$ic" />
       </HBox>
       <HBox spacing="5" alignment="CENTER_LEFT">
-        <Label text="Phone:" styleClass="cell_small_label" />
         <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       </HBox>
       <HBox spacing="5" alignment="CENTER_LEFT">
-        <Label text="Address:" styleClass="cell_small_label" />
         <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       </HBox>
       <HBox spacing="5" alignment="CENTER_LEFT">
-        <Label text="Email:" styleClass="cell_small_label" />
         <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       </HBox>
       <HBox spacing="5" alignment="TOP_LEFT">


### PR DESCRIPTION
Editted the fxml code for main window such that when the left pane is reduced in size, the labels for the fields wont be truncated (eg ...street 32.... for address).

Now its all corrected so that its truncated only from the back (eg Address: Clementi street 32...)

Closes #148. Let me know if theres any issues!