### PR TITLE
Fix addnote hyperlink

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -307,7 +307,7 @@ What a successful `add` command looks like:
 
 **<i class="material-icons-outlined">lightbulb</i> Useful Tip:**<br>
 
-A person can have a note included (See [addnote](#adding-a-note--addnote) command).
+A person can have a note included (See [addnote](#adding-a-note-addnote) command).
 </div>
 
 **Possible Error that you might encounter:**


### PR DESCRIPTION
Changed the hyperlink to use https://ay2324s2-cs2103t-f14-2.github.io/tp/UserGuide.html#adding-a-note-addnote (notice there is only one dash between note and addnote). Closes #235 .